### PR TITLE
Fix Naming/FileName offense

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -21,11 +21,3 @@ Metrics/MethodLength:
 # Configuration parameters: CountKeywordArgs, MaxOptionalParameters.
 Metrics/ParameterLists:
   Max: 7
-
-# Configuration parameters: ExpectMatchingDefinition, CheckDefinitionPathHierarchy, CheckDefinitionPathHierarchyRoots, Regex, IgnoreExecutableScripts, AllowedAcronyms.
-# CheckDefinitionPathHierarchyRoots: lib, spec, test, src
-# AllowedAcronyms: CLI, DSL, ACL, API, ASCII, CPU, CSS, DNS, EOF, GUID, HTML, HTTP, HTTPS, ID, IP, JSON, LHS, QPS, RAM, RHS, RPC, SLA, SMTP, SQL, SSH, TCP, TLS, TTL, UDP, UI, UID, UUID, URI, URL, UTF8, VM, XML, XMPP, XSRF, XSS
-Naming/FileName:
-  Exclude:
-    - 'Rakefile.rb'
-    - 'lib/colore-client.rb'

--- a/README.md
+++ b/README.md
@@ -58,12 +58,13 @@ File.open( 'foo.pdf', 'wb' ) { |f| f.write(pdf) }
 ## Available Methods
 
 ```ruby
-client.create_document doc_id:, filename:, content:, title:, author:, actions:[], callback_url
-client.update_document doc_id:, version:, filename:, content:, title:, author:, actions:[], callback_url:
-client.request_conversion doc_id:, version:, filename:, action: callback_url:
+client.create_document doc_id:, filename:, content:, title:, author:, actions:, callback_url:
+client.update_document doc_id:, filename:, content:, author:, actions:, callback_url:
+client.update_title doc_id:, title:
+client.request_conversion doc_id:, filename:, action:, version:, callback_url:
 client.delete_document doc_id:
 client.delete_version doc_id:, version:
-client.get_document doc_id:, version:, filename:
+client.get_document doc_id:, filename:, version:
 client.get_document_info doc_id:
 client.convert content:, action:, language:
 ```

--- a/bin/colore-client
+++ b/bin/colore-client
@@ -8,7 +8,7 @@ require 'pp'
 BIN_BASE = Pathname.new(__dir__)
 $LOAD_PATH << BIN_BASE.join('../lib')
 
-require 'colore-client'
+require 'colore/client'
 
 DEFAULT_ARGS = {
   base_uri: 'http://localhost:9240/',

--- a/lib/colore-client.rb
+++ b/lib/colore-client.rb
@@ -1,5 +1,0 @@
-# frozen_string_literal: true
-
-require_relative 'colore/client/version'
-require_relative 'colore/errors'
-require_relative 'colore/client'

--- a/lib/colore/client.rb
+++ b/lib/colore/client.rb
@@ -9,6 +9,9 @@ require 'securerandom'
 require 'tempfile'
 require 'uri'
 
+require_relative 'client/version'
+require_relative 'errors'
+
 # The Colore module serves as the namespace for the Colore client and related classes.
 module Colore
   # The name of the 'current' version.

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,7 +13,7 @@ require 'filemagic/ext'
 
 SPEC_BASE = Pathname.new(__dir__)
 
-require 'colore-client'
+require 'colore/client'
 
 def fixture(name)
   SPEC_BASE.join('fixtures', name)


### PR DESCRIPTION
Rename Colore Client according to Rubygems conventions.

Ref: https://guides.rubygems.org/name-your-gem/